### PR TITLE
Fix paths for github build action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,6 +23,12 @@ inputs:
   em_cache_folder:
     default: emsdk-cache
     description: Emscripten cache folder.
+  godot-cpp_folder:
+    default: godot-cpp
+    description: Location of godot-cpp in the repository.
+  gdextension_folder:
+    default: .
+    description: Location of the gdextension project within the repository.
 
 runs:
   using: composite
@@ -99,22 +105,22 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ inputs.gdextension-location }}/${{ inputs.scons-cache }}/
-          ${{ github.workspace }}/${{ inputs.godot-cpp }}/${{ inputs.scons-cache }}/
+          ${{ github.workspace }}/${{ inputs.gdextension_folder }}/${{ inputs.scons-cache }}/
+          ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}/${{ inputs.scons-cache }}/
         key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}_cache
 # Build godot-cpp
     - name: Build godot-cpp Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}/${{ inputs.scons-cache }}/
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} generate_bindings=yes precision=${{ inputs.float-precision }}
-      working-directory: ${{ inputs.godot-cpp }}
+      working-directory: ${{ inputs.godot-cpp_folder }}
 # Build gdextension
     - name: Build GDExtension Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension-location }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension_folder }}/${{ inputs.scons-cache }}/
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} precision=${{ inputs.float-precision }} production=yes
-      working-directory: ${{ inputs.gdextension-location }}
+      working-directory: ${{ inputs.gdextension_folder }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,8 +15,8 @@ inputs:
     default: 'template_debug'
     description: Build type (template_debug or template_release).
   scons-cache:
-    default: .scons-cache/
-    description: Scons cache location.
+    default: '.scons-cache/'
+    description: Scons cache folder name, relative to each scons directory. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/folder/', ending in a slash).
   em_version:
     default: 3.1.39
     description: Emscripten version.
@@ -24,11 +24,11 @@ inputs:
     default: emsdk-cache
     description: Emscripten cache folder.
   godot-cpp_folder:
-    default: godot-cpp
-    description: Location of godot-cpp in the repository.
+    default: 'godot-cpp/'
+    description: Location of godot-cpp in the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/folder/', ending in a slash).
   gdextension_folder:
-    default: .
-    description: Location of the gdextension project within the repository.
+    default: ''
+    description: Location of the gdextension project within the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/folder/', ending in a slash).
 
 runs:
   using: composite
@@ -105,14 +105,14 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ inputs.gdextension_folder }}/${{ inputs.scons-cache }}/
-          ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}/${{ inputs.scons-cache }}/
+          ${{ github.workspace }}/${{ inputs.gdextension_folder }}${{ inputs.scons-cache }}
+          ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}${{ inputs.scons-cache }}
         key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}_cache
 # Build godot-cpp
     - name: Build godot-cpp Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp_folder }}${{ inputs.scons-cache }}
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} generate_bindings=yes precision=${{ inputs.float-precision }}
       working-directory: ${{ inputs.godot-cpp_folder }}
@@ -120,7 +120,7 @@ runs:
     - name: Build GDExtension Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension_folder }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension_folder }}${{ inputs.scons-cache }}
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} precision=${{ inputs.float-precision }} production=yes
       working-directory: ${{ inputs.gdextension_folder }}


### PR DESCRIPTION
This does several things:
- It actually publishes / fixes the parameters, intended for different folder setups of the project
- godot-cpp is actually built now, as intended by the action author. 
    - I'm not sure if we even need to, given that the latter command builds it fine. But that's for another PR to decide.
- It fixes scons caches, making builds a lot faster (only half tested yet).
- It fixed a build error on windows when compiling with doc data (relevant for an upcoming PR).
